### PR TITLE
Add -T option for fair comparison

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "description": "",
   "main": "index.js",
   "scripts": {
-    "ts-node": "ts-node --",
+    "ts-node": "ts-node -T --",
     "esbuild": "node --require esbuild-register --"
   },
   "keywords": [],


### PR DESCRIPTION
Thank you for the great article.

ts-node checks type during execution, while esbuild not. To compare them with the same feature, adding `-T` option would be helpful.

Anyway esbuild is fast.